### PR TITLE
Ledstatus

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ tryfi.pets[0].isLost
 * [TryFi](https://tryfi.com/)
 
 # Version History
+## 0.0.9
+* Bugfix - get LED status based on additional logic that compares the ledOffAt date with the current date/time. Update the boolean to True or False base on the additional date comparison.
+
 ## 0.0.8
 * Bugfix - handle unknown location
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ print(pkg)
 
 setup(
     name="pytryfi", # Replace with your own username
-    version="0.0.8",
+    version="0.0.9",
     author="Steve Babcock",
     author_email="steve.w.babcock@gmail.com",
     description="Python Interface for TryFi Dog Collars",


### PR DESCRIPTION
Added logic that compares the current date/time with the ledOffAt date/time provided by the API since the LEDStatus value can be true but the LED is actually off. This occurs when TryFi turns off the LED themselves.