### PR TITLE
Update Readme to contain more complete examples + activity stats example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pytryfi - Python Interface for TryFi
+````# pytryfi - Python Interface for TryFi
 
 This python interface enables you to gather information about your dogs whereabouts, your user details and any bases you may have.
 
@@ -90,7 +90,73 @@ tryfi.pets[0].monthlySleep
 tryfi.pets[0].dailyNap
 tryfi.pets[0].weeklyNap
 tryfi.pets[0].monthlyNap
+
+#get the pet name
+tryfi.pets[0].name
 ```
+### Fetch Historical Activity and Rest Data
+
+The GraphQL API exposes daily history feeds for activity and rest. You can reuse the bundled fragments to build queries and iterate the results. Example below pulls the latest 30 days for the first pet.
+
+```python
+from pytryfi import PyTryFi
+from pytryfi.common import query
+from pytryfi.const import (
+    FRAGMENT_ACTIVITY_SUMMARY_DETAILS,
+    FRAGMENT_REST_SUMMARY_DETAILS,
+)
+
+tryfi = PyTryFi(username, password)
+pet = tryfi.pets[0]
+limit_days = 30
+
+activity_history_query = (
+        "query {"
+        "  pet (id: \"" + pet.petId + "\") {"
+        "    activitySummaryFeed(cursor: null, period: DAILY, limit: "
+        + str(limit_days)
+        + ") {"
+        "      __typename"
+        "      activitySummaries {"
+        "        __typename"
+        "        ...ActivitySummaryDetails"
+        "      }"
+        "    }"
+        "  }"
+        "}\n"
+        + FRAGMENT_ACTIVITY_SUMMARY_DETAILS
+    )
+
+activity_response = query.query(tryfi.session, activity_history_query)
+for summary in activity_response["data"]["pet"]["activitySummaryFeed"]["activitySummaries"]:
+    print(summary["start"], summary["totalSteps"], summary["stepGoal"])
+
+rest_history_query = (
+        "query {"
+        "  pet (id: \"" + pet.petId + "\") {"
+        "    restSummaryFeed(cursor: null, period: DAILY, limit: "
+        + str(limit_days)
+        + ") {"
+        "      __typename"
+        "      restSummaries {"
+        "        __typename"
+        "        ...RestSummaryDetails"
+        "      }"
+        "    }"
+        "  }"
+        "}\n"
+        + FRAGMENT_REST_SUMMARY_DETAILS
+    )
+
+rest_response = query.query(tryfi.session, rest_history_query)
+for summary in rest_response["data"]["pet"]["restSummaryFeed"]["restSummaries"]:
+    sleep_amounts = summary.get("data", {}).get("sleepAmounts", [])
+    sleep_minutes = next((item.get("duration") for item in sleep_amounts if item.get("type") == "SLEEP"), 0)
+    nap_minutes = next((item.get("duration") for item in sleep_amounts if item.get("type") == "NAP"), 0)
+    print(summary["start"], sleep_minutes, nap_minutes)
+```
+
+Set `limit_days` as needed (TryFi currently caps the feed around 90 days) or switch `period` to `WEEKLY`/`MONTHLY` for alternate rollups.````
 
 ## To Do
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-````# pytryfi - Python Interface for TryFi
+# pytryfi - Python Interface for TryFi
 
 This python interface enables you to gather information about your dogs whereabouts, your user details and any bases you may have.
 
@@ -91,9 +91,45 @@ tryfi.pets[0].dailyNap
 tryfi.pets[0].weeklyNap
 tryfi.pets[0].monthlyNap
 
-#get the pet name
+#get basic info
+tryfi.pets[0].petId
 tryfi.pets[0].name
+tryfi.pets[0].breed
+tryfi.pets[0].gender
+tryfi.pets[0].weight
+tryfi.pets[0].photoLink
+tryfi.pets[0].homeCityState
+tryfi.pets[0].yearOfBirth
+tryfi.pets[0].monthOfBirth
+tryfi.pets[0].dayOfBirth
+
+#get device and location info
+tryfi.pets[0].device
+tryfi.pets[0].currLongitude
+tryfi.pets[0].currLatitude
+tryfi.pets[0].currStartTime
+tryfi.pets[0].currPlaceName
+tryfi.pets[0].currPlaceAddress
+tryfi.pets[0].areaName
+
+#get activity & metrics
+tryfi.pets[0].activityType
+tryfi.pets[0].connectedTo
+tryfi.pets[0].dailyGoal
+tryfi.pets[0].dailySteps
+tryfi.pets[0].dailyTotalDistance
+tryfi.pets[0].weeklyGoal
+tryfi.pets[0].weeklySteps
+tryfi.pets[0].weeklyTotalDistance
+tryfi.pets[0].monthlyGoal
+tryfi.pets[0].monthlySteps
+tryfi.pets[0].monthlyTotalDistance
+
+#get status info
+tryfi.pets[0].lastUpdated
+
 ```
+
 ### Fetch Historical Activity and Rest Data
 
 The GraphQL API exposes daily history feeds for activity and rest. You can reuse the bundled fragments to build queries and iterate the results. Example below pulls the latest 30 days for the first pet.
@@ -156,7 +192,7 @@ for summary in rest_response["data"]["pet"]["restSummaryFeed"]["restSummaries"]:
     print(summary["start"], sleep_minutes, nap_minutes)
 ```
 
-Set `limit_days` as needed (TryFi currently caps the feed around 90 days) or switch `period` to `WEEKLY`/`MONTHLY` for alternate rollups.````
+Set `limit_days` as needed (TryFi currently caps the feed around 90 days) or switch `period` to `WEEKLY`/`MONTHLY` for alternate rollups.
 
 ## To Do
 


### PR DESCRIPTION
I struggled with finding documentation about pet object so this expands the code examples to cover all available properties. I also added an example of getting activity history data using the in-built query module, others can use this to get the data until this is abstracted in the library itself.

**Expanded API Usage Documentation:**

* Added a comprehensive list of available pet attributes, grouped by basic info, device/location info, activity & metrics, and status, showing how to access each property from `tryfi.pets[0]`.

**Historical Data Query Examples:**

* Provided Python code examples demonstrating how to fetch daily activity and rest history for a pet using GraphQL queries, including the use of bundled fragments for detailed summaries.
* Included explanations for customizing the query, such as adjusting the number of days (`limit_days`) and switching between daily, weekly, or monthly data rollups.